### PR TITLE
Get recent participants from `spark-evaluations-recent-participants`

### DIFF
--- a/observer/bin/dry-run.js
+++ b/observer/bin/dry-run.js
@@ -1,23 +1,29 @@
 import * as SparkImpactEvaluator from '@filecoin-station/spark-impact-evaluator'
+import * as SparkEvaluationsRecentParticipants from '@filecoin-station/spark-evaluations-recent-participants'
 import { ethers } from 'ethers'
 
 import { RPC_URL, rpcHeaders } from '../lib/config.js'
 import { observeTransferEvents, observeScheduledRewards } from '../lib/observer.js'
-import { getPgPools } from '@filecoin-station/spark-stats-db'
+import { getStatsPgPool } from '@filecoin-station/spark-stats-db'
 
-const pgPools = await getPgPools()
+const pgPoolStats = await getStatsPgPool()
 
 const fetchRequest = new ethers.FetchRequest(RPC_URL)
 fetchRequest.setHeader('Authorization', rpcHeaders.Authorization || '')
 const provider = new ethers.JsonRpcProvider(fetchRequest, null, { polling: true })
 
 const ieContract = new ethers.Contract(SparkImpactEvaluator.ADDRESS, SparkImpactEvaluator.ABI, provider)
+const recentParticipantsContract = new ethers.Contract(
+  SparkEvaluationsRecentParticipants.ADDRESS,
+  SparkEvaluationsRecentParticipants.ABI,
+  provider
+)
 
-await pgPools.stats.query('DELETE FROM daily_reward_transfers')
+await pgPoolStats.query('DELETE FROM daily_reward_transfers')
 
 await Promise.all([
-  observeTransferEvents(pgPools.stats, ieContract, provider),
-  observeScheduledRewards(pgPools, ieContract)
+  observeTransferEvents(pgPoolStats, ieContract, provider),
+  observeScheduledRewards(pgPoolStats, ieContract, recentParticipantsContract)
 ])
 
-await pgPools.stats.end()
+await pgPoolStats.end()

--- a/observer/lib/observer.js
+++ b/observer/lib/observer.js
@@ -44,7 +44,14 @@ export const observeTransferEvents = async (pgPoolStats, ieContract, provider) =
 export const observeScheduledRewards = async (pgPoolStats, ieContract, recentParticipantsContract) => {
   console.log('Querying scheduled rewards from impact evaluator')
   const participants = await recentParticipantsContract.get()
+  const participantsSeen = new Map()
   for (const address of participants) {
+    // participants contains duplicates
+    if (participantsSeen.has(address)) {
+      continue
+    }
+    participantsSeen.set(address, true)
+
     let scheduledRewards
     try {
       scheduledRewards = await ieContract.rewardsScheduledFor(address)

--- a/observer/test/observer.test.js
+++ b/observer/test/observer.test.js
@@ -131,11 +131,8 @@ describe('observer', () => {
     beforeEach(async () => {
       await pgPools.evaluate.query('DELETE FROM recent_station_details')
       await pgPools.evaluate.query('DELETE FROM recent_participant_subnets')
-      await pgPools.evaluate.query('DELETE FROM daily_participants')
       await pgPools.evaluate.query('DELETE FROM participants')
       await pgPools.stats.query('DELETE FROM daily_scheduled_rewards')
-      await givenDailyParticipants(pgPools.evaluate, today(), ['0xCURRENT'])
-      await givenDailyParticipants(pgPools.evaluate, '2000-01-01', ['0xOLD'])
     })
 
     it('observes scheduled rewards', async () => {
@@ -149,7 +146,15 @@ describe('observer', () => {
           }
         }
       }
-      await observeScheduledRewards(pgPools, ieContract)
+      /** @type {any} */
+      const recentParticipantsContract = {
+        get: async () => ['0xCURRENT']
+      }
+      await observeScheduledRewards(
+        pgPools.stats,
+        ieContract,
+        recentParticipantsContract
+      )
       const { rows } = await pgPools.stats.query(`
         SELECT participant_address, scheduled_rewards
         FROM daily_scheduled_rewards
@@ -164,7 +169,15 @@ describe('observer', () => {
       const ieContract = {
         rewardsScheduledFor: async () => 200n
       }
-      await observeScheduledRewards(pgPools, ieContract)
+      /** @type {any} */
+      const recentParticipantsContract = {
+        get: async () => ['0xCURRENT']
+      }
+      await observeScheduledRewards(
+        pgPools.stats,
+        ieContract,
+        recentParticipantsContract
+      )
       const { rows } = await pgPools.stats.query(`
         SELECT participant_address, scheduled_rewards
         FROM daily_scheduled_rewards

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
         "observer",
         "stats"
       ],
+      "dependencies": {
+        "@filecoin-station/spark-evaluations-recent-participants": "^3.0.0"
+      },
       "devDependencies": {
         "@types/mocha": "^10.0.7",
         "@types/pg": "^8.11.8",
@@ -104,6 +107,11 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/@filecoin-station/spark-evaluations-recent-participants": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@filecoin-station/spark-evaluations-recent-participants/-/spark-evaluations-recent-participants-3.0.0.tgz",
+      "integrity": "sha512-t55W0+1gqgIaUW/GvNEGzfRegnn0oKYlfHpNfhj2hb0/5fDyphSwoeQYZkVD4BZg758gJci18uC5wnocUUx0uQ=="
     },
     "node_modules/@filecoin-station/spark-impact-evaluator": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
     "env": [
       "mocha"
     ]
+  },
+  "dependencies": {
+    "@filecoin-station/spark-evaluations-recent-participants": "^3.0.0"
   }
 }


### PR DESCRIPTION
This removes one db coupling between spark-stats and spark-evaluate