### PR TITLE
Optimize 'Leaderboard - FIL Earned' query: add migration for participant_id and update query using ROW_NUMBER() for faster performance

### DIFF
--- a/db/migrations/023.do.add-participant-id.sql
+++ b/db/migrations/023.do.add-participant-id.sql
@@ -1,0 +1,30 @@
+-- Add participant_id columns to both tables
+ALTER TABLE daily_scheduled_rewards ADD COLUMN participant_id INTEGER;
+ALTER TABLE daily_reward_transfers ADD COLUMN participant_id INTEGER;
+
+-- Backfill participant_id in daily_scheduled_rewards based on participant_address
+WITH address_mapping AS (
+  SELECT DISTINCT participant_address AS address,
+         ROW_NUMBER() OVER (ORDER BY participant_address) AS generated_id
+  FROM daily_scheduled_rewards
+)
+UPDATE daily_scheduled_rewards dsr
+SET participant_id = am.generated_id
+FROM address_mapping am
+WHERE dsr.participant_address = am.address;
+
+-- Backfill participant_id in daily_reward_transfers using the same mapping
+WITH address_mapping AS (
+  SELECT DISTINCT participant_address AS address,
+         ROW_NUMBER() OVER (ORDER BY participant_address) AS generated_id
+  FROM daily_scheduled_rewards
+)
+UPDATE daily_reward_transfers drt
+SET participant_id = am.generated_id
+FROM address_mapping am
+WHERE drt.to_address = am.address;
+
+-- Create indexes for better performance
+CREATE INDEX idx_daily_scheduled_rewards_pid_day ON daily_scheduled_rewards (participant_id, day DESC);
+CREATE INDEX idx_daily_reward_transfers_pid_day ON daily_reward_transfers (participant_id, day);
+

--- a/stats/lib/platform-stats-fetchers.js
+++ b/stats/lib/platform-stats-fetchers.js
@@ -131,25 +131,34 @@ export const fetchAccumulativeDailyParticipantCount = async (pgPool, filter) => 
  */
 export const fetchTopEarningParticipants = async (pgPool, filter) => {
   // The query combines "transfers until filter.to" with "latest scheduled rewards as of today".
-  // As a result, it produces incorrect result if `to` is different from `now()`.
-  // See https://github.com/filecoin-station/spark-stats/pull/170#discussion_r1664080395
   assert(filter.to === today(), 400, 'filter.to must be today, other values are not supported')
+  
   const { rows } = await pgPool.query(`
     WITH latest_scheduled_rewards AS (
-      SELECT DISTINCT ON (participant_address) participant_address, scheduled_rewards
-      FROM daily_scheduled_rewards
-      ORDER BY participant_address, day DESC
+      SELECT participant_id, scheduled_rewards, participant_address
+      FROM (
+        SELECT participant_id, scheduled_rewards, participant_address,
+               ROW_NUMBER() OVER (PARTITION BY participant_id ORDER BY day DESC) AS rn
+        FROM daily_scheduled_rewards
+        WHERE day <= $2
+      ) ranked
+      WHERE rn = 1
     )
     SELECT
+      COALESCE(drt.participant_id, lsr.participant_id) AS participant_id,
       COALESCE(drt.to_address, lsr.participant_address) as participant_address,
       COALESCE(SUM(drt.amount), 0) + COALESCE(lsr.scheduled_rewards, 0) as total_rewards
     FROM daily_reward_transfers drt
     FULL OUTER JOIN latest_scheduled_rewards lsr
-      ON drt.to_address = lsr.participant_address
+      ON drt.participant_id = lsr.participant_id
     WHERE (drt.day >= $1 AND drt.day <= $2) OR drt.day IS NULL
-    GROUP BY COALESCE(drt.to_address, lsr.participant_address), lsr.scheduled_rewards
+    GROUP BY 
+      COALESCE(drt.participant_id, lsr.participant_id),
+      COALESCE(drt.to_address, lsr.participant_address),
+      lsr.scheduled_rewards
     ORDER BY total_rewards DESC
   `, [filter.from, filter.to])
+  
   return rows
 }
 


### PR DESCRIPTION
This PR optimizes the SQL query used for the "Leaderboard - FIL Earned" panel. The changes include:

- Adding a new migration script (023.do.add-participant-id.sql) that introduces a participant_id column and corresponding indexes to replace text-based joins.
- Updating the query to use ROW_NUMBER() to efficiently select the latest scheduled rewards per participant.

Performance Improvements:
1. Execution time is reduced by ~41%.
2. Sorting is ~40% faster and consumes ~48% less disk space.
3. Aggregation is ~42% faster, using ~40% less memory.
4. Joins are streamlined, avoiding unnecessary hashing, and leveraging ROW_NUMBER() for better efficiency.
5. Query planning time is cut by ~92%.

### Performance Comparison
![1Q](https://github.com/user-attachments/assets/9d298ace-e2b0-42f8-9afe-6718ff4eee4a)

#### After Optimization:
![2Q](https://github.com/user-attachments/assets/c0229b78-ec1f-40d0-ac7f-bf40148600f8)

Testing:
I have tested these changes in my local environment with backfilled test data fetch from the API, and the results confirm a significant performance improvement.

Please review and let me know if any further changes are needed.