### PR TITLE
Add daily desktop users route

### DIFF
--- a/db/test-helpers.js
+++ b/db/test-helpers.js
@@ -16,3 +16,21 @@ export const givenDailyParticipants = async (pgPool, day, participantAddresses) 
     Array.from(ids.values())
   ])
 }
+
+/**
+ * @param {import('./typings.js').Queryable} pgPool
+ * @param {string} day
+ * @param {string} platform
+ * @param {number} count
+ */
+export const givenDailyDesktopUsers = async (pgPool, day, platform, count) => {
+  await pgPool.query(`
+    INSERT INTO daily_desktop_users (day, platform, user_count)
+    VALUES ($1, $2, $3)
+    ON CONFLICT DO NOTHING
+  `, [
+    day,
+    platform,
+    count
+  ])
+}

--- a/stats/lib/platform-routes.js
+++ b/stats/lib/platform-routes.js
@@ -6,7 +6,8 @@ import {
   fetchParticipantsWithTopMeasurements,
   fetchDailyStationMeasurementCounts,
   fetchParticipantsSummary,
-  fetchAccumulativeDailyParticipantCount
+  fetchAccumulativeDailyParticipantCount,
+  fetchDailyDesktopUsers
 } from './platform-stats-fetchers.js'
 
 import { filterPreHandlerHook, filterOnSendHook } from './request-helpers.js'
@@ -23,6 +24,9 @@ export const addPlatformRoutes = (app, pgPools) => {
     })
     app.get('/stations/monthly', async (/** @type {RequestWithFilter} */ request, reply) => {
       reply.send(await fetchMonthlyStationCount(pgPools.evaluate, request.filter))
+    })
+    app.get('/stations/desktop/daily', async (/** @type {RequestWithFilter} */ request, reply) => {
+      reply.send(await fetchDailyDesktopUsers(pgPools.stats, request.filter))
     })
     app.get('/measurements/daily', async (/** @type {RequestWithFilter} */ request, reply) => {
       reply.send(await fetchDailyStationMeasurementCounts(pgPools.evaluate, request.filter))

--- a/stats/lib/platform-stats-fetchers.js
+++ b/stats/lib/platform-stats-fetchers.js
@@ -195,7 +195,7 @@ export const fetchDailyDesktopUsers = async (pgPool, filter) => {
     if (platform === null) {
       days[day].total += total
     } else {
-      days[day].platform_breakdown.push({ platform, total })
+      days[day].platforms.push({ platform, total })
     }
   }
 

--- a/stats/lib/platform-stats-fetchers.js
+++ b/stats/lib/platform-stats-fetchers.js
@@ -188,7 +188,7 @@ export const fetchDailyDesktopUsers = async (pgPool, filter) => {
       days[day] = {
         day,
         total: 0,
-        platform_breakdown: []
+        platforms: []
       }
     }
 

--- a/stats/test/platform-routes.test.js
+++ b/stats/test/platform-routes.test.js
@@ -500,8 +500,8 @@ describe('Platform Routes HTTP request handler', () => {
       await assertResponseStatus(res, 200)
       const daily = await res.json()
       assert.deepStrictEqual(daily, [
-        { day: '2000-01-01', total: 30, platform_breakdown: [{ platform: 'darwin', total: 10 }, { platform: 'linux', total: 10 }, { platform: 'win32', total: 10 }] },
-        { day: '2000-01-03', total: 20, platform_breakdown: [{ platform: 'darwin', total: 5 }, { platform: 'linux', total: 5 }, { platform: 'win32', total: 10 }] }
+        { day: '2000-01-01', total: 30, platforms: [{ platform: 'darwin', total: 10 }, { platform: 'linux', total: 10 }, { platform: 'win32', total: 10 }] },
+        { day: '2000-01-03', total: 20, platforms: [{ platform: 'darwin', total: 5 }, { platform: 'linux', total: 5 }, { platform: 'win32', total: 10 }] }
       ])
     })
   })


### PR DESCRIPTION
Adds route that returns total number of desktop users per day with platform breakdown.

Related to:
-  https://github.com/CheckerNetwork/roadmap/issues/207
- #311 