### PR TITLE
Remove platform column and add endpoint to read daily desktop users

### DIFF
--- a/db/migrations/007.do.drop-platform-column-from-daily-desktop-users.sql
+++ b/db/migrations/007.do.drop-platform-column-from-daily-desktop-users.sql
@@ -1,0 +1,3 @@
+ALTER TABLE daily_desktop_users DROP CONSTRAINT daily_desktop_users_pkey;
+ALTER TABLE daily_desktop_users DROP COLUMN platform;
+ALTER TABLE daily_desktop_users ADD PRIMARY KEY (day);

--- a/db/test-helpers.js
+++ b/db/test-helpers.js
@@ -16,3 +16,19 @@ export const givenDailyParticipants = async (pgPool, day, participantAddresses) 
     Array.from(ids.values())
   ])
 }
+
+/**
+ * @param {import('./typings.js').Queryable} pgPool
+ * @param {string} day
+ * @param {number} count
+ */
+export const givenDailyDesktopUsers = async (pgPool, day, count) => {
+  await pgPool.query(`
+    INSERT INTO daily_desktop_users (day, user_count)
+    VALUES ($1, $2)
+    ON CONFLICT DO NOTHING
+  `, [
+    day,
+    count
+  ])
+}

--- a/observer/test/observer.test.js
+++ b/observer/test/observer.test.js
@@ -217,21 +217,33 @@ describe('observer', () => {
     it('observes desktop users count', async () => {
       await observeYesterdayDesktopUsers(pgPools.stats, {
         collectRows: async () => [
-          { platform: 'win32', platform_count: 10 },
-          { platform: 'darwin', platform_count: 5 },
-          { platform: 'linux', platform_count: 3 }
+          { count: 18 }
         ]
       })
 
       const { rows } = await pgPools.stats.query(`
-        SELECT day::TEXT, platform, user_count
+        SELECT day::TEXT, user_count
         FROM daily_desktop_users
         ORDER BY user_count DESC
       `)
       assert.deepStrictEqual(rows, [
-        { day: yesterday(), platform: 'win32', user_count: 10 },
-        { day: yesterday(), platform: 'darwin', user_count: 5 },
-        { day: yesterday(), platform: 'linux', user_count: 3 }
+        { day: yesterday(), user_count: 18 }
+      ])
+
+      await observeYesterdayDesktopUsers(pgPools.stats, {
+        collectRows: async () => [
+          { count: 25 },
+          { count: 11 }
+        ]
+      })
+
+      const { rows: updatedRows } = await pgPools.stats.query(`
+        SELECT day::TEXT, user_count
+        FROM daily_desktop_users
+        ORDER BY user_count DESC
+      `)
+      assert.deepStrictEqual(updatedRows, [
+        { day: yesterday(), user_count: 36 }
       ])
     })
   })

--- a/stats/lib/platform-routes.js
+++ b/stats/lib/platform-routes.js
@@ -6,7 +6,8 @@ import {
   fetchParticipantsWithTopMeasurements,
   fetchDailyStationMeasurementCounts,
   fetchParticipantsSummary,
-  fetchAccumulativeDailyParticipantCount
+  fetchAccumulativeDailyParticipantCount,
+  fetchDailyDesktopUsers
 } from './platform-stats-fetchers.js'
 
 import { filterPreHandlerHook, filterOnSendHook } from './request-helpers.js'
@@ -23,6 +24,9 @@ export const addPlatformRoutes = (app, pgPools) => {
     })
     app.get('/stations/monthly', async (/** @type {RequestWithFilter} */ request, reply) => {
       reply.send(await fetchMonthlyStationCount(pgPools.evaluate, request.filter))
+    })
+    app.get('/stations/desktop/daily', async (/** @type {RequestWithFilter} */ request, reply) => {
+      reply.send(await fetchDailyDesktopUsers(pgPools.stats, request.filter))
     })
     app.get('/measurements/daily', async (/** @type {RequestWithFilter} */ request, reply) => {
       reply.send(await fetchDailyStationMeasurementCounts(pgPools.evaluate, request.filter))

--- a/stats/lib/platform-stats-fetchers.js
+++ b/stats/lib/platform-stats-fetchers.js
@@ -164,3 +164,20 @@ export const fetchParticipantsSummary = async (pgPool) => {
     participant_count: Number(rows[0].count)
   }
 }
+
+/**
+ * @param {Queryable} pgPool
+ * @param {import('./typings.js').DateRangeFilter} filter
+ */
+export const fetchDailyDesktopUsers = async (pgPool, filter) => {
+  const { rows } = await pgPool.query(`
+    SELECT
+      day::TEXT,
+      user_count::INT
+    FROM daily_desktop_users
+    WHERE day >= $1 AND day <= $2
+    ORDER BY day`,
+  [filter.from, filter.to])
+
+  return rows
+}

--- a/stats/lib/platform-stats-fetchers.js
+++ b/stats/lib/platform-stats-fetchers.js
@@ -173,7 +173,7 @@ export const fetchDailyDesktopUsers = async (pgPool, filter) => {
   const { rows } = await pgPool.query(`
     SELECT
       day::TEXT,
-      user_count::INT
+      user_count
     FROM daily_desktop_users
     WHERE day >= $1 AND day <= $2
     ORDER BY day`,


### PR DESCRIPTION
### Motivation

In my 1:1 with @patrickwoodhead, I raised the question of whether we need to track the platform used by desktop users to run the app. We concluded that we're only interested in the number of users running the Station app.

### Changelog

- Drop `platform` column from `daily_desktop_users` table
- Simplify InfluxDB query to only return daily desktop users count
- Add endpoint to read daily desktop users count in a given time range

Follow up #311 
Related to https://github.com/CheckerNetwork/roadmap/issues/207