### PR TITLE
feat: per client rsr api endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ Base URL: http://stats.filspark.com/
 
   http://stats.filspark.com/client/f0215074/deals/eligible/summary
 
-- `GET /client/retrieval-success-rate/summary?from=<day>&to=<day>`
+- `GET /clients/retrieval-success-rate/summary?from=<day>&to=<day>`
 
-  http://stats.filspark.com/client/retrieval-success-rate/summary
+  http://stats.filspark.com/clients/retrieval-success-rate/summary
 
 
 - `GET /client/:id/retrieval-success-rate/summary?from=<day>&to=<day>`

--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ Base URL: http://stats.filspark.com/
 
   http://stats.filspark.com/client/f0215074/deals/eligible/summary
 
+- `GET /client/retrieval-success-rate/summary?from=<day>&to=<day>`
+
+  http://stats.filspark.com/client/retrieval-success-rate/summary
+
+
+- `GET /client/:id/retrieval-success-rate/summary?from=<day>&to=<day>`
+
+  http://stats.filspark.com/client/f0215074/retrieval-success-rate/summary
+
+
 - `GET /allocator/:id/deals/eligible/summary`
 
   http://stats.filspark.com/allocator/f03015751/deals/eligible/summary

--- a/package-lock.json
+++ b/package-lock.json
@@ -326,82 +326,38 @@
       }
     },
     "node_modules/@filecoin-station/spark-evaluate": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@filecoin-station/spark-evaluate/-/spark-evaluate-1.0.4.tgz",
-      "integrity": "sha512-5KbBALxXJNbWVm2JRHItOnru4Nd2TFztIn1TOQ6VBcsuSp5nCgZAJitNIuB84amoiF3JrAetV1fTePgIoCwuEA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@filecoin-station/spark-evaluate/-/spark-evaluate-1.1.0.tgz",
+      "integrity": "sha512-e857IGRJK4OZET4EhvRHxl6M3Do9WzR4VsbJnrVZhdvF/2P60wBS0PaX8651Ou6iKY4hS2zThxh7MvfVXPuF/g==",
       "dependencies": {
         "@filecoin-station/spark-impact-evaluator": "^1.2.4",
         "@glif/filecoin-address": "^3.0.12",
         "@influxdata/influxdb-client": "^1.35.0",
         "@ipld/car": "^5.4.0",
         "@ipld/dag-json": "^10.2.3",
-        "@sentry/node": "^8.50.0",
-        "@ucanto/core": "^10.2.0",
-        "@ucanto/principal": "^9.0.1",
-        "@web3-storage/car-block-validator": "^1.2.0",
+        "@sentry/node": "^9.2.0",
+        "@ucanto/core": "^10.3.0",
+        "@ucanto/principal": "^9.0.2",
+        "@web3-storage/car-block-validator": "^1.2.1",
         "@web3-storage/w3up-client": "^16.5.2",
         "debug": "^4.4.0",
         "drand-client": "^1.2.6",
         "ethers": "^6.13.5",
-        "ipfs-car": "^1.2.0",
         "ipfs-unixfs-exporter": "^13.6.1",
         "just-percentile": "^4.2.0",
         "k-closest": "^1.3.0",
         "ms": "^2.1.3",
-        "multiformats": "^13.3.1",
+        "multiformats": "^13.3.2",
         "p-map": "^7.0.3",
         "p-retry": "^6.2.1",
-        "pg": "^8.13.1",
+        "pg": "^8.13.3",
         "postgrator": "^8.0.0"
       }
     },
-    "node_modules/@filecoin-station/spark-evaluate/node_modules/@opentelemetry/api-logs": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.53.0.tgz",
-      "integrity": "sha512-8HArjKx+RaAI8uEIgcORbZIPklyh1YLjPSBus8hjRmvLi6DeFzgOcdZ7KwPabKj8mXF8dX0hyfAyGfycz0DbFw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@filecoin-station/spark-evaluate/node_modules/@prisma/instrumentation": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-5.22.0.tgz",
-      "integrity": "sha512-LxccF392NN37ISGxIurUljZSh1YWnphO34V5a0+T7FVQG2u9bhAXRTJpgmQ3483woVhkraQZFF7cbRrpbw/F4Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.8",
-        "@opentelemetry/instrumentation": "^0.49 || ^0.50 || ^0.51 || ^0.52.0 || ^0.53.0",
-        "@opentelemetry/sdk-trace-base": "^1.22"
-      }
-    },
-    "node_modules/@filecoin-station/spark-evaluate/node_modules/@prisma/instrumentation/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.53.0.tgz",
-      "integrity": "sha512-DMwg0hy4wzf7K73JJtl95m/e0boSoWhH07rfvHvYzQtBD3Bmv0Wc1x733vyZBqmFm8OjJD0/pfiUg1W3JjFX0A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.53.0",
-        "@types/shimmer": "^1.2.0",
-        "import-in-the-middle": "^1.8.1",
-        "require-in-the-middle": "^7.1.1",
-        "semver": "^7.5.2",
-        "shimmer": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
     "node_modules/@filecoin-station/spark-evaluate/node_modules/@sentry/node": {
-      "version": "8.54.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-8.54.0.tgz",
-      "integrity": "sha512-z9ak481OtCw3V4l55ke/9FOiorF2J/niO1J1gvGefXpgFucpw0M3qqEFjB5cpg9HoZM8Y1WtA1OFusfTAnvcXg==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-9.2.0.tgz",
+      "integrity": "sha512-QDOCIs8hTnwPE34FwYL1oIQneqpqyl85MOEfHnv1K7WZ4XYaHMvlJi1vSDr155buFC9K6JkINTw5yJmU1Pi5mA==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
@@ -427,33 +383,32 @@
         "@opentelemetry/instrumentation-mongoose": "0.46.0",
         "@opentelemetry/instrumentation-mysql": "0.45.0",
         "@opentelemetry/instrumentation-mysql2": "0.45.0",
-        "@opentelemetry/instrumentation-nestjs-core": "0.44.0",
-        "@opentelemetry/instrumentation-pg": "0.50.0",
+        "@opentelemetry/instrumentation-pg": "0.51.0",
         "@opentelemetry/instrumentation-redis-4": "0.46.0",
         "@opentelemetry/instrumentation-tedious": "0.18.0",
         "@opentelemetry/instrumentation-undici": "0.10.0",
         "@opentelemetry/resources": "^1.30.1",
         "@opentelemetry/sdk-trace-base": "^1.30.1",
         "@opentelemetry/semantic-conventions": "^1.28.0",
-        "@prisma/instrumentation": "5.22.0",
-        "@sentry/core": "8.54.0",
-        "@sentry/opentelemetry": "8.54.0",
-        "import-in-the-middle": "^1.11.2"
+        "@prisma/instrumentation": "6.2.1",
+        "@sentry/core": "9.2.0",
+        "@sentry/opentelemetry": "9.2.0",
+        "import-in-the-middle": "^1.12.0"
       },
       "engines": {
-        "node": ">=14.18"
+        "node": ">=18"
       }
     },
     "node_modules/@filecoin-station/spark-evaluate/node_modules/@sentry/opentelemetry": {
-      "version": "8.54.0",
-      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-8.54.0.tgz",
-      "integrity": "sha512-Tkmd8bmXMx0PKZF53ywk/FfvDrphX8NdPH5N53HxyMvGxSf2trZkTuOSFJg6zKibyGYO6+PUeGO3g2WJKUxwGA==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-9.2.0.tgz",
+      "integrity": "sha512-ksd3M+KXuHt5vsPcqyy77YxVP0yb27J2LD19fasiybOPedb90XjynEk29zVBmW2iEPt8Ddw55FKDNVnHFEbUjw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "8.54.0"
+        "@sentry/core": "9.2.0"
       },
       "engines": {
-        "node": ">=14.18"
+        "node": ">=18"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.9.0",
@@ -462,18 +417,6 @@
         "@opentelemetry/instrumentation": "^0.57.1",
         "@opentelemetry/sdk-trace-base": "^1.30.1",
         "@opentelemetry/semantic-conventions": "^1.28.0"
-      }
-    },
-    "node_modules/@filecoin-station/spark-evaluate/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@filecoin-station/spark-impact-evaluator": {
@@ -649,22 +592,6 @@
         "rabin-rs": "^2.1.0"
       }
     },
-    "node_modules/@ipld/unixfs/node_modules/@multiformats/murmur3": {
-      "version": "2.1.8",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "multiformats": "^13.0.0",
-        "murmurhash3js-revisited": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@ipld/unixfs/node_modules/@multiformats/murmur3/node_modules/multiformats": {
-      "version": "13.3.1",
-      "license": "Apache-2.0 OR MIT"
-    },
     "node_modules/@ipld/unixfs/node_modules/multiformats": {
       "version": "11.0.2",
       "license": "Apache-2.0 OR MIT",
@@ -794,31 +721,33 @@
       }
     },
     "node_modules/@multiformats/blake2": {
-      "version": "1.0.13",
-      "license": "(Apache-2.0 AND MIT)",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@multiformats/blake2/-/blake2-2.0.2.tgz",
+      "integrity": "sha512-AOWu6Tyuk5UoT5m4faB6ntVnPB8EmuD6rn18s4cCgHNEGgsamT8GdvjP9DYjzFHQVaP/0L3CaKqWQqJlXx9ecw==",
+      "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "blakejs": "^1.1.1",
-        "multiformats": "^9.5.4"
+        "blakejs": "^1.2.1",
+        "multiformats": "^13.0.0"
       }
-    },
-    "node_modules/@multiformats/blake2/node_modules/multiformats": {
-      "version": "9.9.0",
-      "license": "(Apache-2.0 AND MIT)"
     },
     "node_modules/@multiformats/murmur3": {
-      "version": "1.1.3",
-      "license": "(Apache-2.0 AND MIT)",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-2.1.8.tgz",
+      "integrity": "sha512-6vId1C46ra3R1sbJUOFCZnsUIveR9oF20yhPmAFxPm0JfrX3/ZRCgP3YDrBzlGoEppOXnA9czHeYc0T9mB6hbA==",
+      "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "multiformats": "^9.5.4",
+        "multiformats": "^13.0.0",
         "murmurhash3js-revisited": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
-    },
-    "node_modules/@multiformats/murmur3/node_modules/multiformats": {
-      "version": "9.9.0",
-      "license": "(Apache-2.0 AND MIT)"
     },
     "node_modules/@multiformats/sha3": {
       "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@multiformats/sha3/-/sha3-2.0.17.tgz",
+      "integrity": "sha512-7ik6pk178qLO2cpNucgf48UnAOBMkq/2H92DP4SprZOJqM9zqbVaKS7XyYW6UvhRsDJ3wi921fYv1ihTtQHLtA==",
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "js-sha3": "^0.8.0",
@@ -827,6 +756,8 @@
     },
     "node_modules/@multiformats/sha3/node_modules/multiformats": {
       "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
       "license": "(Apache-2.0 AND MIT)"
     },
     "node_modules/@noble/curves": {
@@ -1283,31 +1214,15 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-nestjs-core": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.44.0.tgz",
-      "integrity": "sha512-t16pQ7A4WYu1yyQJZhRKIfUNvl5PAaF2pEteLvgJb/BWdd1oNuU1rOYt4S825kMy+0q4ngiX281Ss9qiwHfxFQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/instrumentation": "^0.57.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
     "node_modules/@opentelemetry/instrumentation-pg": {
-      "version": "0.50.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.50.0.tgz",
-      "integrity": "sha512-TtLxDdYZmBhFswm8UIsrDjh/HFBeDXd4BLmE8h2MxirNHewLJ0VS9UUddKKEverb5Sm2qFVjqRjcU+8Iw4FJ3w==",
+      "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.51.0.tgz",
+      "integrity": "sha512-/NStIcUWUofc11dL7tSgMk25NqvhtbHDCncgm+yc4iJF8Ste2Q/lwUitjfxqj4qWM280uFmBEtcmtMMjbjRU7Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.26.0",
         "@opentelemetry/instrumentation": "^0.57.0",
-        "@opentelemetry/semantic-conventions": "1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
         "@opentelemetry/sql-common": "^0.40.1",
         "@types/pg": "8.6.1",
         "@types/pg-pool": "2.0.6"
@@ -1317,15 +1232,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-pg/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.27.0.tgz",
-      "integrity": "sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/instrumentation-pg/node_modules/@types/pg": {
@@ -1528,18 +1434,6 @@
         "murmurhash3js-revisited": "^3.0.0"
       }
     },
-    "node_modules/@perma/map/node_modules/@multiformats/murmur3": {
-      "version": "2.1.8",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "multiformats": "^13.0.0",
-        "murmurhash3js-revisited": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "dev": true,
@@ -1697,12 +1591,12 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "8.54.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.54.0.tgz",
-      "integrity": "sha512-03bWf+D1j28unOocY/5FDB6bUHtYlm6m6ollVejhg45ZmK9iPjdtxNWbrLsjT1WRym0Tjzowu+A3p+eebYEv0Q==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.2.0.tgz",
+      "integrity": "sha512-REnEuneWyv3DkZfr0ZCQOZRCkBxUuWMY7aJ7BwWU9t3CFRUIPO0ePiXb2eZJEkDtalJK+m9pSTDUbChtrzQmLA==",
       "license": "MIT",
       "engines": {
-        "node": ">=14.18"
+        "node": ">=18"
       }
     },
     "node_modules/@sentry/node": {
@@ -1750,26 +1644,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@sentry/node/node_modules/@opentelemetry/instrumentation-pg": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.51.0.tgz",
-      "integrity": "sha512-/NStIcUWUofc11dL7tSgMk25NqvhtbHDCncgm+yc4iJF8Ste2Q/lwUitjfxqj4qWM280uFmBEtcmtMMjbjRU7Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "^1.26.0",
-        "@opentelemetry/instrumentation": "^0.57.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
-        "@opentelemetry/sql-common": "^0.40.1",
-        "@types/pg": "8.6.1",
-        "@types/pg-pool": "2.0.6"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
     "node_modules/@sentry/node/node_modules/@sentry/core": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.1.0.tgz",
@@ -1777,72 +1651,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@sentry/node/node_modules/@types/pg": {
-      "version": "8.6.1",
-      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.1.tgz",
-      "integrity": "sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "pg-protocol": "*",
-        "pg-types": "^2.2.0"
-      }
-    },
-    "node_modules/@sentry/node/node_modules/pg-types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
-      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
-      "license": "MIT",
-      "dependencies": {
-        "pg-int8": "1.0.1",
-        "postgres-array": "~2.0.0",
-        "postgres-bytea": "~1.0.0",
-        "postgres-date": "~1.0.4",
-        "postgres-interval": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@sentry/node/node_modules/postgres-array": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
-      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@sentry/node/node_modules/postgres-bytea": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
-      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@sentry/node/node_modules/postgres-date": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
-      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@sentry/node/node_modules/postgres-interval": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
-      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "xtend": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/@sentry/opentelemetry": {
@@ -2000,22 +1808,22 @@
       }
     },
     "node_modules/@ucanto/core": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/@ucanto/core/-/core-10.2.1.tgz",
-      "integrity": "sha512-tPLrQUQEbo4d+vFB7hZdbMYaFqqJwczGz3LiGZMW7uWC9g1imFryJcedeLBqiKNYdQmBY70Yuj9QFDEope6mfQ==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@ucanto/core/-/core-10.3.0.tgz",
+      "integrity": "sha512-hPJDuGKSzQdfe0ZrRzNRGz+AeEeVd3ed+St8LUn6/mJMncsqOGzqUbHNVc6sOMGAI4incSGKAO7AXOKd6DRObw==",
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@ipld/car": "^5.1.0",
         "@ipld/dag-cbor": "^9.0.0",
         "@ipld/dag-ucan": "^3.4.5",
-        "@ucanto/interface": "^10.1.1",
+        "@ucanto/interface": "^10.2.0",
         "multiformats": "^13.3.1"
       }
     },
     "node_modules/@ucanto/interface": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@ucanto/interface/-/interface-10.1.1.tgz",
-      "integrity": "sha512-FHSA7eAN1pbJyzcMRFs9ioHlPQUpE3CfHxLGkCF9AU4HMl7G2YdgzeeOdiD3Li7Ur7EFUwEhZDoVMNKGH+7h1g==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@ucanto/interface/-/interface-10.2.0.tgz",
+      "integrity": "sha512-k49byxjAKJEW+ru1RBJ8VNCBCxWSMY7P25DqOocCGECUfod38uqj4Z5dmvlM8ax3HRd7U5MTp+B9Q/gzWXnjfQ==",
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@ipld/dag-ucan": "^3.4.5",
@@ -2023,24 +1831,18 @@
       }
     },
     "node_modules/@ucanto/principal": {
-      "version": "9.0.1",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@ucanto/principal/-/principal-9.0.2.tgz",
+      "integrity": "sha512-RE3Rj0oz4wh4C9p2JJZB9+QLd7Fi3lCixrbHgAvEoSyTNpvz6ky8DGNtttmD5j3O94z13qdVdIoSRY6DQZXfAg==",
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
-        "@ipld/dag-ucan": "^3.4.0",
+        "@ipld/dag-ucan": "^3.4.5",
         "@noble/curves": "^1.2.0",
         "@noble/ed25519": "^1.7.3",
         "@noble/hashes": "^1.3.2",
-        "@ucanto/interface": "^10.0.0",
-        "multiformats": "^11.0.2",
+        "@ucanto/interface": "^10.1.1",
+        "multiformats": "^13.3.1",
         "one-webcrypto": "^1.0.3"
-      }
-    },
-    "node_modules/@ucanto/principal/node_modules/multiformats": {
-      "version": "11.0.2",
-      "license": "Apache-2.0 OR MIT",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
       }
     },
     "node_modules/@ucanto/transport": {
@@ -2169,25 +1971,25 @@
       }
     },
     "node_modules/@web3-storage/car-block-validator": {
-      "version": "1.2.0",
-      "license": "(Apache-2.0 AND MIT)",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@web3-storage/car-block-validator/-/car-block-validator-1.2.1.tgz",
+      "integrity": "sha512-ueVZXReusjE//5BGLBEoRzyMVZcTJSoz4KOZjX6+mDHAdmjXDxWB+/+23PP8XPGwgyTdxt+s9xEPK0vZkW0oLQ==",
+      "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@multiformats/blake2": "^1.0.13",
-        "@multiformats/murmur3": "^1.1.3",
+        "@multiformats/blake2": "^2.0.2",
+        "@multiformats/murmur3": "^2.1.8",
         "@multiformats/sha3": "^2.0.15",
-        "multiformats": "9.9.0",
-        "uint8arrays": "^3.1.1"
+        "multiformats": "^13.3.1",
+        "uint8arrays": "^5.1.0"
       }
     },
-    "node_modules/@web3-storage/car-block-validator/node_modules/multiformats": {
-      "version": "9.9.0",
-      "license": "(Apache-2.0 AND MIT)"
-    },
     "node_modules/@web3-storage/car-block-validator/node_modules/uint8arrays": {
-      "version": "3.1.1",
-      "license": "MIT",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
+      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
+      "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "multiformats": "^9.4.2"
+        "multiformats": "^13.0.0"
       }
     },
     "node_modules/@web3-storage/data-segment": {
@@ -3898,6 +3700,8 @@
     },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "license": "MIT"
     },
     "node_modules/fast-decode-uri-component": {
@@ -4056,16 +3860,6 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
-      }
-    },
-    "node_modules/files-from-path": {
-      "version": "1.1.1",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.10"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/fill-range": {
@@ -4340,6 +4134,7 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/graphemer": {
@@ -4349,6 +4144,8 @@
     },
     "node_modules/hamt-sharding": {
       "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/hamt-sharding/-/hamt-sharding-3.0.6.tgz",
+      "integrity": "sha512-nZeamxfymIWLpVcAN0CRrb7uVq3hCOGj9IcL6NMA6VVCVWqj+h9Jo/SmaWuS92AEDf1thmHsM5D5c70hM3j2Tg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "sparse-array": "^1.3.1",
@@ -4357,6 +4154,8 @@
     },
     "node_modules/hamt-sharding/node_modules/uint8arrays": {
       "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
+      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "multiformats": "^13.0.0"
@@ -4554,6 +4353,8 @@
     },
     "node_modules/interface-blockstore": {
       "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-5.3.1.tgz",
+      "integrity": "sha512-nhgrQnz6yUQEqxTFLhlOBurQOy5lWlwCpgFmZ3GTObTVTQS9RZjK/JTozY6ty9uz2lZs7VFJSqwjWAltorJ4Vw==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "interface-store": "^6.0.0",
@@ -4562,6 +4363,8 @@
     },
     "node_modules/interface-store": {
       "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-6.0.2.tgz",
+      "integrity": "sha512-KSFCXtBlNoG0hzwNa0RmhHtrdhzexp+S+UY2s0rWTBJyfdEIgn6i6Zl9otVqrcFYbYrneBT7hbmHQ8gE0C3umA==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/internal-slot": {
@@ -4584,57 +4387,10 @@
         "node": ">= 10"
       }
     },
-    "node_modules/ipfs-car": {
-      "version": "1.2.0",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "@ipld/car": "^5.1.0",
-        "@ipld/dag-cbor": "^9.0.0",
-        "@ipld/dag-json": "^10.0.1",
-        "@ipld/dag-pb": "^4.0.2",
-        "@ipld/unixfs": "^3.0.0",
-        "@web3-storage/car-block-validator": "^1.0.1",
-        "files-from-path": "^1.0.0",
-        "ipfs-unixfs-exporter": "^13.0.1",
-        "multiformats": "^13.0.1",
-        "sade": "^1.8.1",
-        "varint": "^6.0.0"
-      },
-      "bin": {
-        "🚘": "bin.js",
-        "ipfs-car": "bin.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/ipfs-car/node_modules/@ipld/unixfs": {
-      "version": "3.0.0",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "@ipld/dag-pb": "^4.0.0",
-        "@multiformats/murmur3": "^2.1.3",
-        "@perma/map": "^1.0.2",
-        "actor": "^2.3.1",
-        "multiformats": "^13.0.1",
-        "protobufjs": "^7.1.2",
-        "rabin-rs": "^2.1.0"
-      }
-    },
-    "node_modules/ipfs-car/node_modules/@multiformats/murmur3": {
-      "version": "2.1.8",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "multiformats": "^13.0.0",
-        "murmurhash3js-revisited": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
     "node_modules/ipfs-unixfs": {
       "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-11.2.0.tgz",
+      "integrity": "sha512-J8FN1qM5nfrDo8sQKQwfj0+brTg1uBfZK2vY9hxci33lcl3BFrsELS9+1+4q/8tO1ASKfxZO8W3Pi2O4sVX2Lg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "protons-runtime": "^5.5.0",
@@ -4643,6 +4399,8 @@
     },
     "node_modules/ipfs-unixfs-exporter": {
       "version": "13.6.1",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-13.6.1.tgz",
+      "integrity": "sha512-pYPI4oBTWao2//sFzAL0pURyojn79q/u5BuK6L5/nVbVUQVw6DcVP5uB1ySdWlTM2H+0Zlhp9+OL9aJBRIICpg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@ipld/dag-cbor": "^9.2.1",
@@ -4661,18 +4419,6 @@
         "multiformats": "^13.2.3",
         "p-queue": "^8.0.1",
         "progress-events": "^1.0.1"
-      }
-    },
-    "node_modules/ipfs-unixfs-exporter/node_modules/@multiformats/murmur3": {
-      "version": "2.1.8",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "multiformats": "^13.0.0",
-        "murmurhash3js-revisited": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
       }
     },
     "node_modules/ipfs-utils": {
@@ -5103,6 +4849,8 @@
     },
     "node_modules/it-filter": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-3.1.1.tgz",
+      "integrity": "sha512-TOXmVuaSkxlLp2hXKoMTra0WMZMKVFxE3vSsbIA+PbADNCBAHhjJ/lM31vBOUTddHMO34Ku++vU8T9PLlBxQtg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "it-peekable": "^3.0.0"
@@ -5118,10 +4866,14 @@
     },
     "node_modules/it-last": {
       "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/it-last/-/it-last-3.0.6.tgz",
+      "integrity": "sha512-M4/get95O85u2vWvWQinF8SJUc/RPC5bWTveBTYXvlP2q5TF9Y+QhT3nz+CRCyS2YEc66VJkyl/da6WrJ0wKhw==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/it-map": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/it-map/-/it-map-3.1.1.tgz",
+      "integrity": "sha512-9bCSwKD1yN1wCOgJ9UOl+46NQtdatosPWzxxUk2NdTLwRPXLh+L7iwCC9QKsbgM60RQxT/nH8bKMqm3H/o8IHQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "it-peekable": "^3.0.0"
@@ -5129,6 +4881,8 @@
     },
     "node_modules/it-merge": {
       "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-3.0.5.tgz",
+      "integrity": "sha512-2l7+mPf85pyRF5pqi0dKcA54E5Jm/2FyY5GsOaN51Ta0ipC7YZ3szuAsH8wOoB6eKY4XsU4k2X+mzPmFBMayEA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "it-pushable": "^3.2.3"
@@ -5136,6 +4890,8 @@
     },
     "node_modules/it-parallel": {
       "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/it-parallel/-/it-parallel-3.0.8.tgz",
+      "integrity": "sha512-URLhs6eG4Hdr4OdvgBBPDzOjBeSSmI+Kqex2rv/aAyYClME26RYHirLVhZsZP5M+ZP6M34iRlXk8Wlqtezuqpg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "p-defer": "^4.0.1"
@@ -5143,10 +4899,14 @@
     },
     "node_modules/it-peekable": {
       "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-3.0.5.tgz",
+      "integrity": "sha512-JWQOGMt6rKiPcY30zUVMR4g6YxkpueTwHVE7CMs/aGqCf4OydM6w+7ZM3PvmO1e0TocjuR4aL8xyZWR46cTqCQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/it-pipe": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-3.0.1.tgz",
+      "integrity": "sha512-sIoNrQl1qSRg2seYSBH/3QxWhJFn9PKYvOf/bHdtCBF0bnghey44VyASsWzn5dAx0DCDDABq1hZIuzKmtBZmKA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "it-merge": "^3.0.0",
@@ -5160,6 +4920,8 @@
     },
     "node_modules/it-pushable": {
       "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.2.3.tgz",
+      "integrity": "sha512-gzYnXYK8Y5t5b/BnJUr7glfQLO4U5vyb05gPx/TyTw+4Bv1zM9gFk4YsOrnulWefMewlphCjKkakFvj1y99Tcg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "p-defer": "^4.0.0"
@@ -5167,6 +4929,8 @@
     },
     "node_modules/it-stream-types": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-2.0.2.tgz",
+      "integrity": "sha512-Rz/DEZ6Byn/r9+/SBCuJhpPATDF9D+dz5pbgSUyBsCDtza6wtNATrz/jz1gDyNanC3XdLboriHnOC925bZRBww==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/it-to-stream": {
@@ -5218,6 +4982,8 @@
     },
     "node_modules/js-sha3": {
       "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
       "license": "MIT"
     },
     "node_modules/js-tokens": {
@@ -5647,19 +5413,14 @@
       "version": "1.0.3",
       "license": "MIT"
     },
-    "node_modules/mri": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "license": "MIT"
     },
     "node_modules/multiformats": {
-      "version": "13.3.1",
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.3.2.tgz",
+      "integrity": "sha512-qbB0CQDt3QKfiAzZ5ZYjLFOs+zW43vA4uyM8g27PeEuXZybUOFyjrVdP93HPBHMoglibwfkdVwbzfUq8qGcH6g==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/murmurhash3js-revisited": {
@@ -5959,7 +5720,9 @@
       }
     },
     "node_modules/p-queue": {
-      "version": "8.0.1",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.1.0.tgz",
+      "integrity": "sha512-mxLDbbGIBEXTJL0zEx8JIylaj3xQ7Z/7eEVjcF9fJX4DBiH9oqe+oahYnlKKxm0Ci9TlWTyhSHgygxMxjIB2jw==",
       "license": "MIT",
       "dependencies": {
         "eventemitter3": "^5.0.1",
@@ -5988,7 +5751,9 @@
       }
     },
     "node_modules/p-timeout": {
-      "version": "6.1.3",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
+      "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
       "license": "MIT",
       "engines": {
         "node": ">=14.16"
@@ -6446,6 +6211,8 @@
     },
     "node_modules/progress-events": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/progress-events/-/progress-events-1.0.1.tgz",
+      "integrity": "sha512-MOzLIwhpt64KIVN64h1MwdKWiyKFNc/S6BoYKPIVUHFg0/eIEyBulhWCgn678v/4c0ri3FdGuzXymNCv02MUIw==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/prop-types": {
@@ -6482,6 +6249,8 @@
     },
     "node_modules/protons-runtime": {
       "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.5.0.tgz",
+      "integrity": "sha512-EsALjF9QsrEk6gbCx3lmfHxVN0ah7nG3cY7GySD4xf4g8cr7g543zB88Foh897Sr1RQJ9yDCUsoT1i1H/cVUFA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "uint8-varint": "^2.0.2",
@@ -6491,6 +6260,8 @@
     },
     "node_modules/protons-runtime/node_modules/uint8arrays": {
       "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
+      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "multiformats": "^13.0.0"
@@ -6750,16 +6521,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/sade": {
-      "version": "1.8.1",
-      "license": "MIT",
-      "dependencies": {
-        "mri": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/safe-array-concat": {
       "version": "1.1.2",
       "dev": true,
@@ -6971,6 +6732,8 @@
     },
     "node_modules/sparse-array": {
       "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/sparse-array/-/sparse-array-1.3.2.tgz",
+      "integrity": "sha512-ZT711fePGn3+kQyLuv1fpd3rNSkNF8vd5Kv2D+qnOANeyKs3fx6bUMGWRPvgTTcYV64QMqZKZwcuaQSP3AZ0tg==",
       "license": "ISC"
     },
     "node_modules/split2": {
@@ -7403,6 +7166,8 @@
     },
     "node_modules/uint8-varint": {
       "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.4.tgz",
+      "integrity": "sha512-FwpTa7ZGA/f/EssWAb5/YV6pHgVF1fViKdW8cWaEarjB8t7NyofSWBdOTyFPaGuUG4gx3v1O3PQ8etsiOs3lcw==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "uint8arraylist": "^2.0.0",
@@ -7411,6 +7176,8 @@
     },
     "node_modules/uint8-varint/node_modules/uint8arrays": {
       "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
+      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "multiformats": "^13.0.0"
@@ -7770,7 +7537,7 @@
         "pg": "^8.13.3"
       },
       "devDependencies": {
-        "@filecoin-station/spark-evaluate": "^1.0.4",
+        "@filecoin-station/spark-evaluate": "^1.1.0",
         "mocha": "^11.1.0",
         "standard": "^17.1.2"
       }

--- a/stats/lib/routes.js
+++ b/stats/lib/routes.js
@@ -70,7 +70,7 @@ export const addRoutes = (app, pgPools, SPARK_API_BASE_URL) => {
     app.get('/miner/:minerId/retrieval-success-rate/summary', async (/** @type {RequestWithFilterAndMinerId} */ request, reply) => {
       reply.send(await fetchDailyMinerRSRSummary(pgPools, request.filter, request.params.minerId))
     })
-    app.get('/client/retrieval-success-rate/summary', async (/** @type {RequestWithFilter} */ request, reply) => {
+    app.get('/clients/retrieval-success-rate/summary', async (/** @type {RequestWithFilter} */ request, reply) => {
       reply.send(await fetchClientsRSRSummary(pgPools, request.filter))
     })
     app.get('/client/:clientId/retrieval-success-rate/summary', async (/** @type {RequestWithFilterAndClientId} */ request, reply) => {

--- a/stats/lib/routes.js
+++ b/stats/lib/routes.js
@@ -13,12 +13,15 @@ import {
   fetchDailyMinerRSRSummary,
   fetchDailyRetrievalTimings,
   fetchDailyMinerRetrievalTimings,
-  fetchMinersTimingsSummary
+  fetchMinersTimingsSummary,
+  fetchDailyClientRSRSummary,
+  fetchClientsRSRSummary
 } from './stats-fetchers.js'
 
 /** @typedef {import('./typings.js').RequestWithFilter} RequestWithFilter */
 /** @typedef {import('./typings.js').RequestWithFilterAndAddress} RequestWithFilterAndAddress */
 /** @typedef {import('./typings.js').RequestWithFilterAndMinerId} RequestWithFilterAndMinerId */
+/** @typedef {import('./typings.js').RequestWithFilterAndClientId} RequestWithFilterAndClientId */
 
 export const addRoutes = (app, pgPools, SPARK_API_BASE_URL) => {
   app.register(async app => {
@@ -66,6 +69,12 @@ export const addRoutes = (app, pgPools, SPARK_API_BASE_URL) => {
     })
     app.get('/miner/:minerId/retrieval-success-rate/summary', async (/** @type {RequestWithFilterAndMinerId} */ request, reply) => {
       reply.send(await fetchDailyMinerRSRSummary(pgPools, request.filter, request.params.minerId))
+    })
+    app.get('/client/retrieval-success-rate/summary', async (/** @type {RequestWithFilter} */ request, reply) => {
+      reply.send(await fetchClientsRSRSummary(pgPools, request.filter))
+    })
+    app.get('/client/:clientId/retrieval-success-rate/summary', async (/** @type {RequestWithFilterAndClientId} */ request, reply) => {
+      reply.send(await fetchDailyClientRSRSummary(pgPools, request.filter, request.params.clientId))
     })
   })
 

--- a/stats/lib/stats-fetchers.js
+++ b/stats/lib/stats-fetchers.js
@@ -1,3 +1,4 @@
+import assert from 'node:assert'
 /** @typedef {import('@filecoin-station/spark-stats-db').PgPools} PgPools */
 /**
  * @param {PgPools} pgPools
@@ -376,15 +377,21 @@ export const fetchClientsRSRSummary = async (pgPools, filter) => {
     filter.from,
     filter.to
   ])
-  const stats = rows.map(r => ({
-    client_id: r.client_id,
-    total: r.total,
-    successful: r.successful,
-    success_rate: r.total > 0 ? r.successful / r.total : null,
-    successful_http: r.successful_http ?? null,
-    // successful_http might be null because the column was added later
-    success_rate_http: r.total > 0 && r.successful_http !== null ? r.successful_http / r.total : null
-  }))
+  const stats = rows.map(r => {
+    // All values are configured to be NOT NULL on the database level
+    assert.ok(r.successful !== null, 'successful should not be null')
+    assert.ok(r.total !== null, 'total should not be null')
+    assert.ok(r.successful_http !== null, 'successful_http should not be null')
+    return {
+      client_id: r.client_id,
+      total: r.total,
+      successful: r.successful,
+      success_rate: r.total > 0 ? r.successful / r.total : null,
+      successful_http: r.successful_http,
+      // successful_http might be null because the column was added later
+      success_rate_http: r.total > 0 ? r.successful_http / r.total : null
+    }
+  })
   return stats
 }
 
@@ -409,14 +416,20 @@ export const fetchDailyClientRSRSummary = async (pgPools, { from, to }, clientId
     from,
     to
   ])
-  const stats = rows.map(r => ({
-    day: r.day,
-    total: r.total,
-    successful: r.successful,
-    success_rate: r.total > 0 ? r.successful / r.total : null,
-    successful_http: r.successful_http ?? null,
-    // successful_http might be null because the column was added later
-    success_rate_http: r.total > 0 && r.successful_http !== null ? r.successful_http / r.total : null
-  }))
+  const stats = rows.map(r => {
+    // All values are configured to be NOT NULL on the database level
+    assert.ok(r.successful !== null, 'successful should not be null')
+    assert.ok(r.total !== null, 'total should not be null')
+    assert.ok(r.successful_http !== null, 'successful_http should not be null')
+    return {
+      day: r.day,
+      total: r.total,
+      successful: r.successful,
+      success_rate: r.total > 0 ? r.successful / r.total : null,
+      successful_http: r.successful_http,
+      // successful_http might be null because the column was added later
+      success_rate_http: r.total > 0 ? r.successful_http / r.total : null
+    }
+  })
   return stats
 }

--- a/stats/lib/stats-fetchers.js
+++ b/stats/lib/stats-fetchers.js
@@ -356,3 +356,67 @@ export const fetchMinersTimingsSummary = async (pgPools, { from, to }) => {
   ])
   return rows
 }
+
+/**
+ * Fetches the retrieval stats summary for all miners for given date range.
+ * @param {PgPools} pgPools
+ * @param {import('./typings.js').DateRangeFilter} filter
+ */
+export const fetchClientsRSRSummary = async (pgPools, filter) => {
+  const { rows } = await pgPools.evaluate.query(`
+    SELECT 
+    client_id, 
+    SUM(total) as total, 
+    SUM(successful) as successful, 
+    SUM(successful_http) as successful_http
+    FROM daily_client_retrieval_stats
+    WHERE day >= $1 AND day <= $2
+    GROUP BY client_id
+   `, [
+    filter.from,
+    filter.to
+  ])
+  const stats = rows.map(r => ({
+    client_id: r.client_id,
+    total: r.total,
+    successful: r.successful,
+    success_rate: r.total > 0 ? r.successful / r.total : null,
+    successful_http: r.successful_http ?? null,
+    // successful_http might be null because the column was added later
+    success_rate_http: r.total > 0 && r.successful_http !== null ? r.successful_http / r.total : null
+  }))
+  return stats
+}
+
+/**
+ * Fetches the retrieval stats summary for a single client for given date range.
+ * @param {PgPools} pgPools
+ * @param {import('./typings.js').DateRangeFilter} filter
+ * @param {string} clientId
+ */
+export const fetchDailyClientRSRSummary = async (pgPools, { from, to }, clientId) => {
+  const { rows } = await pgPools.evaluate.query(`
+    SELECT 
+    day::TEXT, 
+    SUM(total) as total, SUM(successful) as successful, 
+    SUM(successful_http) as successful_http
+    FROM daily_client_retrieval_stats
+    WHERE client_id = $1 AND day >= $2 AND day <= $3
+    GROUP BY day
+    ORDER BY day
+   `, [
+    clientId,
+    from,
+    to
+  ])
+  const stats = rows.map(r => ({
+    day: r.day,
+    total: r.total,
+    successful: r.successful,
+    success_rate: r.total > 0 ? r.successful / r.total : null,
+    successful_http: r.successful_http ?? null,
+    // successful_http might be null because the column was added later
+    success_rate_http: r.total > 0 && r.successful_http !== null ? r.successful_http / r.total : null
+  }))
+  return stats
+}

--- a/stats/lib/stats-fetchers.js
+++ b/stats/lib/stats-fetchers.js
@@ -1,4 +1,3 @@
-import assert from 'node:assert'
 /** @typedef {import('@filecoin-station/spark-stats-db').PgPools} PgPools */
 /**
  * @param {PgPools} pgPools
@@ -378,10 +377,6 @@ export const fetchClientsRSRSummary = async (pgPools, filter) => {
     filter.to
   ])
   const stats = rows.map(r => {
-    // All values are configured to be NOT NULL on the database level
-    assert.ok(r.successful !== null, 'successful should not be null')
-    assert.ok(r.total !== null, 'total should not be null')
-    assert.ok(r.successful_http !== null, 'successful_http should not be null')
     return {
       client_id: r.client_id,
       total: r.total,
@@ -416,10 +411,6 @@ export const fetchDailyClientRSRSummary = async (pgPools, { from, to }, clientId
     to
   ])
   const stats = rows.map(r => {
-    // All values are configured to be NOT NULL on the database level
-    assert.ok(r.successful !== null, 'successful should not be null')
-    assert.ok(r.total !== null, 'total should not be null')
-    assert.ok(r.successful_http !== null, 'successful_http should not be null')
     return {
       day: r.day,
       total: r.total,

--- a/stats/lib/stats-fetchers.js
+++ b/stats/lib/stats-fetchers.js
@@ -359,7 +359,7 @@ export const fetchMinersTimingsSummary = async (pgPools, { from, to }) => {
 }
 
 /**
- * Fetches the retrieval stats summary for all miners for given date range.
+ * Fetches the retrieval stats summary for all clients for given date range.
  * @param {PgPools} pgPools
  * @param {import('./typings.js').DateRangeFilter} filter
  */
@@ -388,7 +388,6 @@ export const fetchClientsRSRSummary = async (pgPools, filter) => {
       successful: r.successful,
       success_rate: r.total > 0 ? r.successful / r.total : null,
       successful_http: r.successful_http,
-      // successful_http might be null because the column was added later
       success_rate_http: r.total > 0 ? r.successful_http / r.total : null
     }
   })
@@ -427,7 +426,6 @@ export const fetchDailyClientRSRSummary = async (pgPools, { from, to }, clientId
       successful: r.successful,
       success_rate: r.total > 0 ? r.successful / r.total : null,
       successful_http: r.successful_http,
-      // successful_http might be null because the column was added later
       success_rate_http: r.total > 0 ? r.successful_http / r.total : null
     }
   })

--- a/stats/lib/typings.d.ts
+++ b/stats/lib/typings.d.ts
@@ -14,6 +14,9 @@ export type RequestWithFilterAndAddress = RequestWithFilter<{
 export type RequestWithFilterAndMinerId = RequestWithFilter<{
   Parameters: { minerId: string }
 }>
+export type RequestWithFilterAndClientId = RequestWithFilter<{
+  Parameters: { clientId: string }
+}>
 
 declare module 'fastify' {
   export interface FastifyRequest {

--- a/stats/package.json
+++ b/stats/package.json
@@ -9,7 +9,7 @@
     "test": "mocha"
   },
   "devDependencies": {
-    "@filecoin-station/spark-evaluate": "^1.0.4",
+    "@filecoin-station/spark-evaluate": "^1.1.0",
     "mocha": "^11.1.0",
     "standard": "^17.1.2"
   },

--- a/stats/test/app.test.js
+++ b/stats/test/app.test.js
@@ -395,7 +395,7 @@ describe('HTTP request handler', () => {
   })
 
   describe('GET /participant/:address/reward-transfers', () => {
-    it('returns daily reward trainsfers for the given date range', async () => {
+    it('returns daily reward transfers for the given date range', async () => {
       await pgPools.stats.query(`
         INSERT INTO daily_reward_transfers
         (day, to_address, amount, last_checked_block)

--- a/stats/test/app.test.js
+++ b/stats/test/app.test.js
@@ -835,6 +835,42 @@ describe('HTTP request handler', () => {
         { miner_id: 'f1two', ttfb_ms: 789 }
       ])
     })
+    describe('GET /client/{id}/retrieval-success-rate/summary', () => {
+      beforeEach(async () => {
+        await pgPools.evaluate.query('DELETE FROM retrieval_stats')
+      })
+      it('lists daily retrieval stats summary for specified client in given date range', async () => {
+        // before the range
+        await givenClientRetrievalStats(pgPools.evaluate, { day: '2024-01-09', clientId: 'f1oneClient', total: 10, successful: 1, successfulHttp: 1 })
+        await givenClientRetrievalStats(pgPools.evaluate, { day: '2024-01-09', clientId: 'f1twoClient', total: 100, successful: 20, successfulHttp: 10 })
+        // in the range
+        await givenClientRetrievalStats(pgPools.evaluate, { day: '2024-01-20', clientId: 'f1oneClient', total: 20, successful: 1, successfulHttp: 0 })
+        await givenClientRetrievalStats(pgPools.evaluate, { day: '2024-01-20', clientId: 'f1twoClient', total: 200, successful: 60, successfulHttp: 50 })
+        await givenClientRetrievalStats(pgPools.evaluate, { day: '2024-01-10', clientId: 'f1oneClient', total: 10, successful: 1, successfulHttp: 1 })
+        await givenClientRetrievalStats(pgPools.evaluate, { day: '2024-01-10', clientId: 'f1twoClient', total: 100, successful: 50, successfulHttp: 35 })
+        // after the range
+        await givenClientRetrievalStats(pgPools.evaluate, { day: '2024-01-21', clientId: 'f1oneClient', total: 30, successful: 1, successfulHttp: 1 })
+        await givenClientRetrievalStats(pgPools.evaluate, { day: '2024-01-21', clientId: 'f1twoClient', total: 300, successful: 60, successfulHttp: 60 })
+  
+        const res = await fetch(
+          new URL(
+            '/client/f1oneClient/retrieval-success-rate/summary?from=2024-01-10&to=2024-01-20',
+            baseUrl
+          ), {
+            redirect: 'manual'
+          }
+        )
+        await assertResponseStatus(res, 200)
+  
+        const stats = /** @type {{ day: string, success_rate: number }[]} */(
+          await res.json()
+        )
+        assert.deepStrictEqual(stats, [
+          { day: '2024-01-10', success_rate: 1 / 10, total: '10', successful: '1', successful_http: '1', success_rate_http: 1 / 10 },
+          { day: '2024-01-20', success_rate: 1 / 20, total: '20', successful: '1', successful_http: '0', success_rate_http: 0 }
+        ])
+      })
+    })
   })
 })
 
@@ -852,6 +888,23 @@ const givenRetrievalStats = async (pgPool, { day, minerId, total, successful, su
   await pgPool.query(
     'INSERT INTO retrieval_stats (day, miner_id, total, successful, successful_http) VALUES ($1, $2, $3, $4, $5)',
     [day, minerId ?? 'f1test', total, successful, successfulHttp]
+  )
+}
+
+/**
+ *
+ * @param {import('../lib/platform-stats-fetchers.js').Queryable} pgPool
+ * @param {object} data
+ * @param {string} data.day
+ * @param {string} [data.clientId]
+ * @param {number | bigint} data.total
+ * @param {number | bigint } data.successful
+ * @param {number | bigint} [data.successfulHttp]
+ */
+const givenClientRetrievalStats = async (pgPool, { day, clientId, total, successful, successfulHttp }) => {
+  await pgPool.query(
+    'INSERT INTO daily_client_retrieval_stats (day, client_id, total, successful, successful_http) VALUES ($1, $2, $3, $4, $5)',
+    [day, clientId ?? 'f1ClientTest', total, successful, successfulHttp]
   )
 }
 

--- a/stats/test/app.test.js
+++ b/stats/test/app.test.js
@@ -835,9 +835,40 @@ describe('HTTP request handler', () => {
         { miner_id: 'f1two', ttfb_ms: 789 }
       ])
     })
+    describe('GET /clients/retrieval-success-rate/summary', () => {
+      beforeEach(async () => {
+        await pgPools.evaluate.query('DELETE FROM daily_client_retrieval_stats')
+      })
+      it('returns a summary of clients RSR for the given date range', async () => {
+        // before the range
+        await givenClientRetrievalStats(pgPools.evaluate, { day: '2024-01-10', clientId: 'f1oneClient', total: 10, successful: 1, successfulHttp: 1 })
+        await givenClientRetrievalStats(pgPools.evaluate, { day: '2024-01-10', clientId: 'f1twoClient', total: 100, successful: 20, successfulHttp: 10 })
+        // in the range
+        await givenClientRetrievalStats(pgPools.evaluate, { day: '2024-01-11', clientId: 'f1oneClient', total: 20, successful: 1, successfulHttp: 0 })
+        await givenClientRetrievalStats(pgPools.evaluate, { day: '2024-01-11', clientId: 'f1twoClient', total: 200, successful: 150, successfulHttp: 100 })
+        // after the range
+        await givenClientRetrievalStats(pgPools.evaluate, { day: '2024-01-12', clientId: 'f1oneClient', total: 30, successful: 1, successfulHttp: 1 })
+        await givenClientRetrievalStats(pgPools.evaluate, { day: '2024-01-12', clientId: 'f1twoClient', total: 300, successful: 60, successfulHttp: 60 })
+
+        const res = await fetch(
+          new URL(
+            '/clients/retrieval-success-rate/summary?from=2024-01-11&to=2024-01-11',
+            baseUrl
+          ), {
+            redirect: 'manual'
+          }
+        )
+        await assertResponseStatus(res, 200)
+        const stats = await res.json()
+        assert.deepStrictEqual(stats, [
+          { client_id: 'f1oneClient', success_rate: 0.05, total: '20', successful: '1', successful_http: '0', success_rate_http: 0 },
+          { client_id: 'f1twoClient', success_rate: 0.75, total: '200', successful: '150', successful_http: '100', success_rate_http: 100 / 200 }
+        ])
+      })
+    })
     describe('GET /client/{id}/retrieval-success-rate/summary', () => {
       beforeEach(async () => {
-        await pgPools.evaluate.query('DELETE FROM retrieval_stats')
+        await pgPools.evaluate.query('DELETE FROM daily_client_retrieval_stats')
       })
       it('lists daily retrieval stats summary for specified client in given date range', async () => {
         // before the range
@@ -851,7 +882,7 @@ describe('HTTP request handler', () => {
         // after the range
         await givenClientRetrievalStats(pgPools.evaluate, { day: '2024-01-21', clientId: 'f1oneClient', total: 30, successful: 1, successfulHttp: 1 })
         await givenClientRetrievalStats(pgPools.evaluate, { day: '2024-01-21', clientId: 'f1twoClient', total: 300, successful: 60, successfulHttp: 60 })
-  
+
         const res = await fetch(
           new URL(
             '/client/f1oneClient/retrieval-success-rate/summary?from=2024-01-10&to=2024-01-20',
@@ -861,7 +892,7 @@ describe('HTTP request handler', () => {
           }
         )
         await assertResponseStatus(res, 200)
-  
+
         const stats = /** @type {{ day: string, success_rate: number }[]} */(
           await res.json()
         )

--- a/stats/test/app.test.js
+++ b/stats/test/app.test.js
@@ -865,6 +865,25 @@ describe('HTTP request handler', () => {
           { client_id: 'f1twoClient', success_rate: 0.75, total: '200', successful: '150', successful_http: '100', success_rate_http: 100 / 200 }
         ])
       })
+      it('handles total value being smaller or equal to 0', async () => {
+        await givenClientRetrievalStats(pgPools.evaluate, { day: '2024-01-11', clientId: 'f1oneClient', total: 0, successful: 0, successfulHttp: 0 })
+        await givenClientRetrievalStats(pgPools.evaluate, { day: '2024-01-11', clientId: 'f2twoClient', total: -1, successful: 0, successfulHttp: 0 })
+
+        const res = await fetch(
+          new URL(
+            'clients/retrieval-success-rate/summary?from=2024-01-11&to=2024-01-11',
+            baseUrl
+          ), {
+            redirect: 'manual'
+          }
+        )
+        await assertResponseStatus(res, 200)
+        const stats = await res.json()
+        assert.deepStrictEqual(stats, [
+          { client_id: 'f1oneClient', success_rate: null, total: '0', successful: '0', successful_http: '0', success_rate_http: null },
+          { client_id: 'f2twoClient', success_rate: null, total: '-1', successful: '0', successful_http: '0', success_rate_http: null }
+        ])
+      })
     })
     describe('GET /client/{id}/retrieval-success-rate/summary', () => {
       beforeEach(async () => {


### PR DESCRIPTION
### CHANGELOG

1. Per Client RSR summary endpoint
2. Clients RSR summary endpoint

The two new endpoints closely follow the implementation of the [per miner](https://github.com/CheckerNetwork/spark-stats/blob/main/stats/lib/routes.js#L67) and [miners](https://github.com/CheckerNetwork/spark-stats/blob/main/stats/lib/routes.js#L52) RSR summary endpoints. These existing endpoints expose `retrieval_stats` for miner-related statistics.  

This PR introduces the same logic for client-related statistics by exposing the `daily_client_retrieval_stats` table, which was created in this recent [PR](https://github.com/CheckerNetwork/spark-evaluate/pull/481/files).  

Additionally, the tests for these new endpoints follow the same pattern as those for the existing miner RSR stats endpoints, ensuring consistency and reliability.

Closes subtask of https://github.com/CheckerNetwork/roadmap/issues/193 