### PR TITLE
feat: allocator rsr endpoints

### DIFF
--- a/db/package.json
+++ b/db/package.json
@@ -12,7 +12,7 @@
     "standard": "^17.1.2"
   },
   "dependencies": {
-    "@filecoin-station/spark-evaluate": "^1.2.0",
+    "@filecoin-station/spark-evaluate": "^1.3.0",
     "pg": "^8.14.1",
     "postgrator": "^8.0.0"
   },

--- a/observer/package.json
+++ b/observer/package.json
@@ -10,7 +10,7 @@
     "test": "mocha"
   },
   "devDependencies": {
-    "@filecoin-station/spark-evaluate": "^1.2.0",
+    "@filecoin-station/spark-evaluate": "^1.3.0",
     "mocha": "^11.1.0",
     "standard": "^17.1.2"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
       "name": "@filecoin-station/spark-stats-db",
       "version": "1.0.0",
       "dependencies": {
-        "@filecoin-station/spark-evaluate": "^1.2.0",
+        "@filecoin-station/spark-evaluate": "^1.3.0",
         "pg": "^8.14.1",
         "postgrator": "^8.0.0"
       },
@@ -328,31 +328,31 @@
       }
     },
     "node_modules/@filecoin-station/spark-evaluate": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@filecoin-station/spark-evaluate/-/spark-evaluate-1.2.0.tgz",
-      "integrity": "sha512-5pVy7KoEk3SsQ/D3FHy0ZR9iPuBe54XpwAOVX/7f6+melHAN/rjWIVDTRyYWJvao9nQVF2GRrnq/Pc/L7EBI+g==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@filecoin-station/spark-evaluate/-/spark-evaluate-1.3.0.tgz",
+      "integrity": "sha512-S74B75eVkjeu6w9dw8l9rB2fAUbcXT8Ly7EEKwSKXA7UcbeKKo3+MRwhllgYsMGsnjxKROEUI3VQA/omKvlifw==",
       "dependencies": {
         "@filecoin-station/spark-impact-evaluator": "^1.2.4",
         "@glif/filecoin-address": "^3.0.12",
         "@influxdata/influxdb-client": "^1.35.0",
         "@ipld/car": "^5.4.0",
         "@ipld/dag-json": "^10.2.3",
-        "@sentry/node": "^9.2.0",
+        "@sentry/node": "^9.9.0",
         "@ucanto/core": "^10.3.1",
         "@ucanto/principal": "^9.0.2",
-        "@web3-storage/car-block-validator": "^1.2.1",
+        "@web3-storage/car-block-validator": "^1.2.2",
         "@web3-storage/w3up-client": "^16.5.2",
         "debug": "^4.4.0",
         "drand-client": "^1.2.6",
         "ethers": "^6.13.5",
-        "ipfs-unixfs-exporter": "^13.6.1",
+        "ipfs-unixfs-exporter": "^13.6.2",
         "just-percentile": "^4.2.0",
         "k-closest": "^1.3.0",
         "ms": "^2.1.3",
         "multiformats": "^13.3.2",
         "p-map": "^7.0.3",
         "p-retry": "^6.2.1",
-        "pg": "^8.13.3",
+        "pg": "^8.14.1",
         "postgrator": "^8.0.0"
       }
     },
@@ -682,20 +682,14 @@
       }
     },
     "node_modules/@multiformats/sha3": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/@multiformats/sha3/-/sha3-2.0.17.tgz",
-      "integrity": "sha512-7ik6pk178qLO2cpNucgf48UnAOBMkq/2H92DP4SprZOJqM9zqbVaKS7XyYW6UvhRsDJ3wi921fYv1ihTtQHLtA==",
-      "license": "(Apache-2.0 AND MIT)",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@multiformats/sha3/-/sha3-3.0.2.tgz",
+      "integrity": "sha512-fBxODTXa1sOWYB9q6GSFe2HYSVwMEdnPa7c7FgNhr/rMFQ2HGtwmRppTm317HSpGSTUkoTvyKQDNcteJEGU+bg==",
+      "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "js-sha3": "^0.8.0",
-        "multiformats": "^9.5.4"
+        "js-sha3": "^0.9.1",
+        "multiformats": "^13.0.0"
       }
-    },
-    "node_modules/@multiformats/sha3/node_modules/multiformats": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
-      "license": "(Apache-2.0 AND MIT)"
     },
     "node_modules/@noble/curves": {
       "version": "1.2.0",
@@ -1848,14 +1842,14 @@
       }
     },
     "node_modules/@web3-storage/car-block-validator": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@web3-storage/car-block-validator/-/car-block-validator-1.2.1.tgz",
-      "integrity": "sha512-ueVZXReusjE//5BGLBEoRzyMVZcTJSoz4KOZjX6+mDHAdmjXDxWB+/+23PP8XPGwgyTdxt+s9xEPK0vZkW0oLQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@web3-storage/car-block-validator/-/car-block-validator-1.2.2.tgz",
+      "integrity": "sha512-lR9l+ZszhTid5HfZE8ohnGf2RJp2kaBOnoejmsACs3iTNiy+3K09dnPm8MhgBE9RCIgPBKM0CCWXO9l+I6jrKA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@multiformats/blake2": "^2.0.2",
         "@multiformats/murmur3": "^2.1.8",
-        "@multiformats/sha3": "^2.0.15",
+        "@multiformats/sha3": "^3.0.2",
         "multiformats": "^13.3.1",
         "uint8arrays": "^5.1.0"
       }
@@ -1965,6 +1959,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/abort-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/abort-error/-/abort-error-1.0.1.tgz",
+      "integrity": "sha512-fxqCblJiIPdSXIUrxI0PL+eJG49QdP9SQ70qtB65MVAoMr2rASlOyAbJFOylfB467F/f+5BCLJJq58RYi7mGfg==",
+      "license": "Apache-2.0 OR MIT"
     },
     "node_modules/abstract-logging": {
       "version": "2.0.1",
@@ -4265,9 +4265,9 @@
       }
     },
     "node_modules/ipfs-unixfs": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-11.2.0.tgz",
-      "integrity": "sha512-J8FN1qM5nfrDo8sQKQwfj0+brTg1uBfZK2vY9hxci33lcl3BFrsELS9+1+4q/8tO1ASKfxZO8W3Pi2O4sVX2Lg==",
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-11.2.1.tgz",
+      "integrity": "sha512-gUeeX63EFgiaMgcs0cUs2ZUPvlOeEZ38okjK8twdWGZX2jYd2rCk8k/TJ3DSRIDZ2t/aZMv6I23guxHaofZE3w==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "protons-runtime": "^5.5.0",
@@ -4275,9 +4275,9 @@
       }
     },
     "node_modules/ipfs-unixfs-exporter": {
-      "version": "13.6.1",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-13.6.1.tgz",
-      "integrity": "sha512-pYPI4oBTWao2//sFzAL0pURyojn79q/u5BuK6L5/nVbVUQVw6DcVP5uB1ySdWlTM2H+0Zlhp9+OL9aJBRIICpg==",
+      "version": "13.6.2",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-13.6.2.tgz",
+      "integrity": "sha512-U3NkQHvQn5XzxtjSo1/GfoFIoXYY4hPgOlZG5RUrV5ScBI222b3jAHbHksXZuMy7sqPkA9ieeWdOmnG1+0nxyw==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@ipld/dag-cbor": "^9.2.1",
@@ -4725,9 +4725,9 @@
       "license": "ISC"
     },
     "node_modules/it-filter": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-3.1.1.tgz",
-      "integrity": "sha512-TOXmVuaSkxlLp2hXKoMTra0WMZMKVFxE3vSsbIA+PbADNCBAHhjJ/lM31vBOUTddHMO34Ku++vU8T9PLlBxQtg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-3.1.2.tgz",
+      "integrity": "sha512-2AozaGjIvBBiB7t7MpVNug9kwofqmKSpvgW7zhuyvCs6xxDd6FrfvqyfYtlQTKLNP+Io1WeXko1UQhdlK4M0gg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "it-peekable": "^3.0.0"
@@ -4742,42 +4742,42 @@
       }
     },
     "node_modules/it-last": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/it-last/-/it-last-3.0.6.tgz",
-      "integrity": "sha512-M4/get95O85u2vWvWQinF8SJUc/RPC5bWTveBTYXvlP2q5TF9Y+QhT3nz+CRCyS2YEc66VJkyl/da6WrJ0wKhw==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/it-last/-/it-last-3.0.7.tgz",
+      "integrity": "sha512-qG4BTveE6Wzsz5voqaOtZAfZgXTJT+yiaj45vp5S0Vi8oOdgKlRqUeolfvWoMCJ9vwSc/z9pAaNYIza7gA851w==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/it-map": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/it-map/-/it-map-3.1.1.tgz",
-      "integrity": "sha512-9bCSwKD1yN1wCOgJ9UOl+46NQtdatosPWzxxUk2NdTLwRPXLh+L7iwCC9QKsbgM60RQxT/nH8bKMqm3H/o8IHQ==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/it-map/-/it-map-3.1.2.tgz",
+      "integrity": "sha512-G3dzFUjTYHKumJJ8wa9dSDS3yKm8L7qDUnAgzemOD0UMztwm54Qc2v97SuUCiAgbOz/aibkSLImfoFK09RlSFQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "it-peekable": "^3.0.0"
       }
     },
     "node_modules/it-merge": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-3.0.5.tgz",
-      "integrity": "sha512-2l7+mPf85pyRF5pqi0dKcA54E5Jm/2FyY5GsOaN51Ta0ipC7YZ3szuAsH8wOoB6eKY4XsU4k2X+mzPmFBMayEA==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-3.0.9.tgz",
+      "integrity": "sha512-TjY4WTiwe4ONmaKScNvHDAJj6Tw0UeQFp4JrtC/3Mq7DTyhytes7mnv5OpZV4gItpZcs0AgRntpT2vAy2cnXUw==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "it-pushable": "^3.2.3"
+        "it-queueless-pushable": "^2.0.0"
       }
     },
     "node_modules/it-parallel": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/it-parallel/-/it-parallel-3.0.8.tgz",
-      "integrity": "sha512-URLhs6eG4Hdr4OdvgBBPDzOjBeSSmI+Kqex2rv/aAyYClME26RYHirLVhZsZP5M+ZP6M34iRlXk8Wlqtezuqpg==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/it-parallel/-/it-parallel-3.0.9.tgz",
+      "integrity": "sha512-FSg8T+pr7Z1VUuBxEzAAp/K1j8r1e9mOcyzpWMxN3mt33WFhroFjWXV1oYSSjNqcdYwxD/XgydMVMktJvKiDog==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "p-defer": "^4.0.1"
       }
     },
     "node_modules/it-peekable": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-3.0.5.tgz",
-      "integrity": "sha512-JWQOGMt6rKiPcY30zUVMR4g6YxkpueTwHVE7CMs/aGqCf4OydM6w+7ZM3PvmO1e0TocjuR4aL8xyZWR46cTqCQ==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-3.0.6.tgz",
+      "integrity": "sha512-odk9wn8AwFQipy8+tFaZNRCM62riraKZJRysfbmOett9wgJumCwgZFzWUBUwMoiQapEcEVGwjDpMChZIi+zLuQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/it-pipe": {
@@ -4802,6 +4802,17 @@
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "p-defer": "^4.0.0"
+      }
+    },
+    "node_modules/it-queueless-pushable": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/it-queueless-pushable/-/it-queueless-pushable-2.0.0.tgz",
+      "integrity": "sha512-MlNnefWT/ntv5fesrHpxwVIu6ZdtlkN0A4aaJiE5wnmPMBv9ttiwX3UEMf78dFwIj5ZNaU9usYXg4swMEpUNJQ==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "abort-error": "^1.0.1",
+        "p-defer": "^4.0.1",
+        "race-signal": "^1.1.3"
       }
     },
     "node_modules/it-stream-types": {
@@ -4858,9 +4869,9 @@
       }
     },
     "node_modules/js-sha3": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.9.3.tgz",
+      "integrity": "sha512-BcJPCQeLg6WjEx3FE591wVAevlli8lxsxm9/FzV4HXkV49TmBH38Yvrpce6fjbADGMKFrBMGTqrVz3qPIZ88Gg==",
       "license": "MIT"
     },
     "node_modules/js-tokens": {
@@ -6183,6 +6194,12 @@
       "version": "2.1.0",
       "license": "(Apache-2.0 AND MIT)"
     },
+    "node_modules/race-signal": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/race-signal/-/race-signal-1.1.3.tgz",
+      "integrity": "sha512-Mt2NznMgepLfORijhQMncE26IhkmjEphig+/1fKC0OtaKwys/gpvpmswSjoN01SS+VO951mj0L4VIDXdXsjnfA==",
+      "license": "Apache-2.0 OR MIT"
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "dev": true,
@@ -7405,7 +7422,7 @@
         "slug": "^10.0.0"
       },
       "devDependencies": {
-        "@filecoin-station/spark-evaluate": "^1.2.0",
+        "@filecoin-station/spark-evaluate": "^1.3.0",
         "mocha": "^11.1.0",
         "standard": "^17.1.2"
       }
@@ -7424,7 +7441,7 @@
         "pg": "^8.14.1"
       },
       "devDependencies": {
-        "@filecoin-station/spark-evaluate": "^1.2.0",
+        "@filecoin-station/spark-evaluate": "^1.3.0",
         "mocha": "^11.1.0",
         "standard": "^17.1.2"
       }

--- a/stats/lib/routes.js
+++ b/stats/lib/routes.js
@@ -15,7 +15,9 @@ import {
   fetchDailyMinerRetrievalTimings,
   fetchMinersTimingsSummary,
   fetchDailyClientRSRSummary,
-  fetchClientsRSRSummary
+  fetchClientsRSRSummary,
+  fetchAllocatorsRSRSummary,
+  fetchDailyAllocatorRSRSummary
 } from './stats-fetchers.js'
 
 /** @typedef {import('./typings.js').RequestWithFilter} RequestWithFilter */
@@ -75,6 +77,12 @@ export const addRoutes = (app, pgPools, SPARK_API_BASE_URL) => {
     })
     app.get('/client/:clientId/retrieval-success-rate/summary', async (/** @type {RequestWithFilterAndClientId} */ request, reply) => {
       reply.send(await fetchDailyClientRSRSummary(pgPools, request.filter, request.params.clientId))
+    })
+    app.get('/allocators/retrieval-success-rate/summary', async (/** @type {RequestWithFilter} */ request, reply) => {
+      reply.send(await fetchAllocatorsRSRSummary(pgPools, request.filter))
+    })
+    app.get('/allocator/:allocatorId/retrieval-success-rate/summary', async (/** @type {RequestWithFilterAndClientId} */ request, reply) => {
+      reply.send(await fetchDailyAllocatorRSRSummary(pgPools, request.filter, request.params.allocatorId))
     })
   })
 

--- a/stats/lib/stats-fetchers.js
+++ b/stats/lib/stats-fetchers.js
@@ -431,3 +431,69 @@ export const fetchDailyClientRSRSummary = async (pgPools, { from, to }, clientId
   })
   return stats
 }
+
+/**
+ * Fetches the retrieval stats summary for all allocators for given date range.
+ * @param {PgPools} pgPools
+ * @param {import('./typings.js').DateRangeFilter} filter
+ */
+export const fetchAllocatorsRSRSummary = async (pgPools, filter) => {
+  const { rows } = await pgPools.evaluate.query(`
+    SELECT 
+    allocator_id, 
+    SUM(total) as total, 
+    SUM(successful) as successful, 
+    SUM(successful_http) as successful_http
+    FROM daily_allocator_retrieval_stats
+    WHERE day >= $1 AND day <= $2
+    GROUP BY allocator_id
+   `, [
+    filter.from,
+    filter.to
+  ])
+  const stats = rows.map(r => {
+    return {
+      allocator_id: r.allocator_id,
+      total: r.total,
+      successful: r.successful,
+      success_rate: r.total > 0 ? r.successful / r.total : null,
+      successful_http: r.successful_http,
+      success_rate_http: r.total > 0 ? r.successful_http / r.total : null
+    }
+  })
+  return stats
+}
+
+/**
+ * Fetches the retrieval stats summary for a single allocator for given date range.
+ * @param {PgPools} pgPools
+ * @param {import('./typings.js').DateRangeFilter} filter
+ * @param {string} allocatorId
+ */
+export const fetchDailyAllocatorRSRSummary = async (pgPools, { from, to }, allocatorId) => {
+  const { rows } = await pgPools.evaluate.query(`
+    SELECT 
+    day::TEXT, 
+    SUM(total) as total, SUM(successful) as successful, 
+    SUM(successful_http) as successful_http
+    FROM daily_allocator_retrieval_stats
+    WHERE allocator_id = $1 AND day >= $2 AND day <= $3
+    GROUP BY day
+    ORDER BY day
+   `, [
+    allocatorId,
+    from,
+    to
+  ])
+  const stats = rows.map(r => {
+    return {
+      day: r.day,
+      total: r.total,
+      successful: r.successful,
+      success_rate: r.total > 0 ? r.successful / r.total : null,
+      successful_http: r.successful_http,
+      success_rate_http: r.total > 0 ? r.successful_http / r.total : null
+    }
+  })
+  return stats
+}

--- a/stats/package.json
+++ b/stats/package.json
@@ -9,7 +9,7 @@
     "test": "mocha"
   },
   "devDependencies": {
-    "@filecoin-station/spark-evaluate": "^1.2.0",
+    "@filecoin-station/spark-evaluate": "^1.3.0",
     "mocha": "^11.1.0",
     "standard": "^17.1.2"
   },


### PR DESCRIPTION
## Add Allocator Retrieval Success Rate Stats API

This PR adds new endpoints to expose Retrieval Success Rate (RSR) statistics calculated on a per-allocator basis, as requested in #216.

### Changes
- Added new endpoints to fetch retrieval success rate statistics for allocators:
  - `/allocators/retrieval-success-rate/summary` - Gets summary stats across all allocators
  - `/allocator/{id}/retrieval-success-rate/summary` - Gets daily stats for a specific allocator
- Added helper functions to fetch stats from the database:
  - `fetchAllocatorsRSRSummary()` - Aggregates stats across allocators
  - `fetchDailyAllocatorRSRSummary()` - Gets daily stats for single allocator
- Added comprehensive test coverage for new endpoints and helper functions
- Upgraded `@filecoin-station/spark-evaluate` from 1.2.0 to 1.3.0

### Usage
```js
// Get summary for all allocators
GET /allocators/retrieval-success-rate/summary?from=2024-01-01&to=2024-01-31

// Get daily stats for specific allocator
GET /allocator/f1abc.../retrieval-success-rate/summary?from=2024-01-01&to=2024-01-31
```

This is one of the steps required for the larger initiative to provide per-allocator RSR data:
- ✅ spark-api add allocators to retrieval tasks array
- ✅ spark-evaluate code writing the new data
- ✅ REST API in spark-stats exposing new data (this PR)
- ⬜ Visualisation on the Spark Public Dashboard

Closes subtask https://github.com/CheckerNetwork/roadmap/issues/216 (partially - only the stats API component)