### PR TITLE
feat! remove observeScheduledRewards

### DIFF
--- a/observer/bin/dry-run.js
+++ b/observer/bin/dry-run.js
@@ -3,7 +3,7 @@ import { ethers } from 'ethers'
 import assert from 'node:assert'
 
 import { RPC_URL, rpcHeaders } from '../lib/config.js'
-import { observeTransferEvents, observeScheduledRewards, observeRetrievalResultCodes, observeYesterdayDesktopUsers } from '../lib/observer.js'
+import { observeTransferEvents, observeRetrievalResultCodes, observeYesterdayDesktopUsers } from '../lib/observer.js'
 import { createInflux } from '../lib/telemetry.js'
 import { getPgPools } from '@filecoin-station/spark-stats-db'
 
@@ -25,7 +25,6 @@ await pgPools.stats.query('DELETE FROM daily_reward_transfers')
 
 await Promise.all([
   observeTransferEvents(pgPools.stats, ieContract, provider),
-  observeScheduledRewards(pgPools, ieContract),
   observeRetrievalResultCodes(pgPools.stats, influxQueryApi),
   observeYesterdayDesktopUsers(pgPools.stats, influxQueryApi)
 ])

--- a/observer/bin/spark-observer.js
+++ b/observer/bin/spark-observer.js
@@ -11,7 +11,6 @@ import { RPC_URL, rpcHeaders } from '../lib/config.js'
 import { getPgPools } from '@filecoin-station/spark-stats-db'
 import {
   observeTransferEvents,
-  observeScheduledRewards,
   observeRetrievalResultCodes,
   observeYesterdayDesktopUsers
 } from '../lib/observer.js'
@@ -62,11 +61,6 @@ await Promise.all([
     'Transfer events',
     () => observeTransferEvents(pgPools.stats, ieContract, provider),
     ONE_HOUR
-  ),
-  loop(
-    'Scheduled rewards',
-    () => observeScheduledRewards(pgPools, ieContract),
-    24 * ONE_HOUR
   ),
   loop(
     'Retrieval result codes',


### PR DESCRIPTION
Drop the code that's periodically updating the table `daily_scheduled_rewards` and the accompanying unit tests to make CI green.

Note: while I could drop the table `daily_scheduled_rewards` in this pull request, such a change would be more invasive, so I decided to leave that cleanup for another day.